### PR TITLE
Allowed use of mongoid for Rails 5 release

### DIFF
--- a/granalytics.gemspec
+++ b/granalytics.gemspec
@@ -21,5 +21,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.6"
   spec.add_development_dependency "rake"
 
-  spec.add_dependency "mongoid", "~> 5.1"
+  spec.add_dependency "mongoid", ['>= 5.1', '< 6.1']
 end

--- a/lib/assets/javascripts/granalytics.js
+++ b/lib/assets/javascripts/granalytics.js
@@ -194,7 +194,7 @@ var HotColdSurveyOptions = function($el, response) {
     title: subWithResponse($el.data('y-axis-label'), response)
   };
 
-  var allSeries = hotColdSurveySeries(response);
+  var allSeries = hotColdSurveySeries(response, $el.data('hot-key'), $el.data('cold-key'));
   this.series = [{
       name: $el.data('hot-label'),
       data: allSeries.hot
@@ -377,7 +377,7 @@ var timeSummarySeries = function(response) {
 //   hot: [-2, -5, -1],
 //   cold: [4, 3, 13]
 // }
-var hotColdSurveySeries = function(response) {
+var hotColdSurveySeries = function(response, hotKey, coldKey) {
   // response data looks like this:
   //
   // granularity: null
@@ -403,10 +403,7 @@ var hotColdSurveySeries = function(response) {
 
   var data = new AnalyticsData(response),
       series = {labels: [], hot: [], cold: [], max: 0},
-      results = data.results[0][data.keys[0]],
-      firstKey = Object.keys(results)[0],
-      hotKey = Object.keys(results[firstKey])[0],
-      coldKey = Object.keys(results[firstKey])[1];
+      results = data.results[0][data.keys[0]];
 
   for (key in results) {
     if (key.match(/^_/)) {

--- a/lib/granalytics/aggregate.rb
+++ b/lib/granalytics/aggregate.rb
@@ -68,7 +68,7 @@ module Granalytics::Aggregate
 
     def incr(event)
       decorated_event = decorate_event(event)
-      self.aggregate_scope(event).find_one_and_update({'$inc' => upsert_hash(decorated_event)}, {'upsert' => 'true', :new => true})
+      self.aggregate_scope(event).find_one_and_update({'$inc' => upsert_hash(decorated_event)}, {upsert: true})
     end
 
     def aggregate_scope(event)
@@ -107,7 +107,7 @@ module Granalytics::Aggregate
       scope = self.aggregate_scope(event)
       #STDOUT.puts "  Decrementing #{self.name} #{scope.selector}"
 
-      record = scope.find_one_and_update({'$inc' => hash}, {:new => true})
+      record = scope.find_one_and_update({'$inc' => hash}, {upsert: true})
 
       # Then, remove if values empty (this is the opposite of the 'upsert' => 'true' in the #incr method)
       unset_keys = {}

--- a/lib/granalytics/aggregate.rb
+++ b/lib/granalytics/aggregate.rb
@@ -68,7 +68,7 @@ module Granalytics::Aggregate
 
     def incr(event)
       decorated_event = decorate_event(event)
-      self.aggregate_scope(event).find_one_and_update({'$inc' => upsert_hash(decorated_event)}, {upsert: true})
+      self.aggregate_scope(event).find_one_and_update({'$inc' => upsert_hash(decorated_event)}, {upsert: true, return_document: :after})
     end
 
     def aggregate_scope(event)
@@ -105,9 +105,7 @@ module Granalytics::Aggregate
       # First decrement
       hash = downsert_hash(event)
       scope = self.aggregate_scope(event)
-      #STDOUT.puts "  Decrementing #{self.name} #{scope.selector}"
-
-      record = scope.find_one_and_update({'$inc' => hash}, {upsert: true})
+      record = scope.find_one_and_update({'$inc' => hash}, {upsert: true, return_document: :after})
 
       # Then, remove if values empty (this is the opposite of the 'upsert' => 'true' in the #incr method)
       unset_keys = {}
@@ -140,7 +138,6 @@ module Granalytics::Aggregate
         end
 
       end
-      #STDOUT.puts "  Unset keys: #{unset_keys}" if unset_keys.any?
       record
     end
 

--- a/lib/granalytics/version.rb
+++ b/lib/granalytics/version.rb
@@ -1,3 +1,3 @@
 module Granalytics
-  VERSION = "0.0.1"
+  VERSION = "0.0.2"
 end


### PR DESCRIPTION
Looks like mongoid changes version for Rails 5, so let's add in some support to handle if and when we change over to Rails 5.
